### PR TITLE
Cherry picked objconvert_class.php from newer (same as pg_database_cl…

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -18,7 +18,7 @@ SVNREPO="https://svn.dbc.dk/repos/php/OpenLibrary/class_lib/trunk"
 EXTNAME="OLS_class_lib"
 OA_234_REV="117239" # = Oracle OpenAgency 2.34 version
 OA_234_DIFF_REV="124699" # = PostgreSQL OpenAgency 2.34 version
-OA_234_DIFF_LIST="pg_database_class.php pg_wrapper_class.php verbose_json_class.php"
+OA_234_DIFF_LIST="pg_database_class.php pg_wrapper_class.php verbose_json_class.php objconvert_class.php"
 
 set -e
 


### PR DESCRIPTION
Cherry picked objconvert_class.php from newer (same as pg_database_class.php, og_wrapper_class.php and verbose_json_class.php) version to silence php7 warnings about uninitialized variables.