### PR TITLE
Add a guard for empty agencyId to openSearchProfile. This solves VP-262

### DIFF
--- a/shared_test.sh
+++ b/shared_test.sh
@@ -140,7 +140,7 @@ function checkServiceMatch() {
     RES=$(curl -s -o ${OUTPUT} -m 5 -w "%{http_code}" "${URL}" 2>/dev/null)
     if [[ "$RES" == *200 ]] ; then
         if grep "${MATCH}" "${OUTPUT}" &> /dev/null ; then
-            info "Match against ${MATCH} found in service output. Service is OK"
+            info "Match against '${MATCH}' found in service output. Service is OK"
             debug "output: '$(cat ${OUTPUT})'"
             return 0
         fi
@@ -194,9 +194,14 @@ function waitForOk() {
   # docker kill ${VIP_POSTGRES_CONTAINERID} || die "Unable to kill postgres container"
 
   # This uses "service"
+  info "Checking openagency.service call"
   checkServiceMatch "http://${HOST_IP}:${WS_SERVICE_PORT}/server.php?action=service&agencyId=710100&service=orsItemRequest" openagency-php agency_not_found
   # But, we also want this, to check the log when debugging.
+  info "Checking openagency.service call basic"
   checkServiceMatch "http://${HOST_IP}:${WS_SERVICE_PORT}/server.php?action=openSearchProfile&agencyId=710100&profileName=foobar&profileVersion=3" openagency-php openSearchProfileResponse
+  # This is related to VP-262
+  info "Checking openagency.openSearchProfile call with missing agencyId"
+  checkServiceMatch "http://${HOST_IP}:${WS_SERVICE_PORT}/server.php?action=openSearchProfile&agencyId=&profileVersion=3&trackingId=2019-10-02T14:40:09:509991:3648" openagency-php agency_not_found
 }
 
 # Print info about how to stop containers.


### PR DESCRIPTION
This solves VP-262.

The diff looks huge, but that is because of the way the code is structured, this change indents the main part of openSearchProfile. Sigh. 

A diff -w on server.php looks like this:

```diff
# Print info about how to stop containers.
diff --git a/src/server.php b/src/server.php
index cb9a7d1..26703cd 100644
--- a/src/server.php
+++ b/src/server.php
@@ -2705,6 +2705,10 @@ class openAgency extends webServiceServer {
       $this->watch->start('preamble');
       $sql_add = NULL;
       $agency = self::strip_agency($param->agencyId->_value);
+      if (empty($agency)) {
+        Object::set_value($res, 'error', 'agency_not_found');
+        $this->watch->stop('preamble');
+      } else {
         $cache_key = 'OA_opeSP_' . $this->config->get_inifile_hash() . $agency . $param->profileName->_value . $param->profileVersion->_value;
         self::set_cache_expire($this->cache_expire[__FUNCTION__]);
         if ($ret = $this->cache->get($cache_key)) {
@@ -2774,8 +2778,7 @@ class openAgency extends webServiceServer {
                       $profile_name = $profil[$kilde['ID_NR']]['NAME'];
                       $add_to_query = $profil[$kilde['ID_NR']]['ADD_TO_QUERY'];
                       Object::set_value($s, 'sourceSearchable', '1');
-                  }
-                  else
+                    } else
                       Object::set_value($s, 'sourceSearchable', '0');
                     Object::set_value($s, 'sourceContainedIn', $kilde['CONTAINED_IN'], FALSE);
                     Object::set_value($s, 'sourceIdentifier', str_replace('[agency]', $agency, $kilde['IDENTIFIER']));
@@ -2798,8 +2801,7 @@ class openAgency extends webServiceServer {
                   }
                 }
               }
-          }
-          catch (fetException $e) {
+            } catch (fetException $e) {
               VerboseJson::log(FATAL, 'OpenAgency(' . __LINE__ . '):: DB select error: ' . $e->getMessage());
               Object::set_value($res, 'error', 'service_unavailable');
             }
@@ -2827,8 +2829,7 @@ class openAgency extends webServiceServer {
                 unset($s);
               }
               $this->watch->stop('fetch4');
-          }
-          catch (fetException $e) {
+            } catch (fetException $e) {
               $this->watch->stop('sql1');
               $this->watch->stop('sql2');
               $this->watch->stop('sql3');
@@ -2839,6 +2840,7 @@ class openAgency extends webServiceServer {
           }
         }
       }
+    }
     //var_dump($res); var_dump($param); die();
     $this->watch->start("postamble");
     $this->watch->start("p1");

```