### PR TITLE
Simplyfy test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.dbc.dk/dbc-apache-php7
+FROM docker.dbc.dk/dbc-apache-php7:old-202010
 
 LABEL maintainer="iScrum Team <iscrum@dbc.dk>" \
       APACHE_SERVER_NAME="The VirtualHost ServerName set for Apache. The global is set to localhost always. [localhost]" \

--- a/docker/compose/systemtest/docker-compose.yml
+++ b/docker/compose/systemtest/docker-compose.yml
@@ -13,26 +13,14 @@ services:
   # And, an vip image to populate the database (and, that is all it does, folks).
   # Note, that we depend on the latest build on master always. You will need
   # to change this yourself, if you need to do otherwise, e.g. during testing.
-  vip-core:
-    image: docker-i.dbc.dk/vipcore:latest
-    expose:
-      - 8080
-    ports:
-      - 8080
-    environment:
-      - DB_URL=vip_user:vip_password@vip-postgres:5432/vip_db
-      - JAVA_MAX_HEAP_SIZE=2G
-      - CACHE_VIPCORE=1
-      - CACHE_FORS=1
-      - FORSRIGHT_ENDPOINT=https://forsrights.addi.dk/1.2/
 
   # The image under test
   openagency-php:
     image: openagency-php-local/openagency-php${DOCKER_IMAGE_TAG}
     environment:
-      - VIP_CREDENTIALS=psql://vip_user:vip_password@vip-postgres:5432/vip_db
+      - VIP_CREDENTIALS=psql://vip:vippass@vip-postgres:5432/vip_db
       # This is maintained if we need testing of the postgresql parsing thing.
-      # - VIP_CREDENTIALS=host=vip-postgres port=5432 dbname=vip_db user=vip_user password=vip_password connect_timeout=1
+      # - VIP_CREDENTIALS=host=vip-postgres port=5432 dbname=vip_db user=vip password=vippass connect_timeout=1
       - URL_PATH=staging_2.34
       - FORS_RIGHTS=https://forsrights.addi.dk/1.2/?action=forsRights&outputType=php&userIdAut=%s&groupIdAut=%s&passwordAut=%s&ipAddress=%s
       - APACHE_SERVER_NAME=localhost
@@ -40,7 +28,8 @@ services:
       #- HTTP_PROXY_INSECURE_MODE_FOR_TEST_ONLY=1
       - COPA_RS_URL=https://iso18626.addi.dk/copa-rs/app/iso18626/
       - COPA_RS_PASSWD=xxxxxxxxxxxx
-      - CACHE_EXPIRE_LIBRARYRULES=600
+    depends_on:
+      - "vip-postgres"
     expose:
       - 80
     ports:

--- a/docker/compose/systemtest/docker-compose.yml
+++ b/docker/compose/systemtest/docker-compose.yml
@@ -1,5 +1,5 @@
 # This compose file is run by Jenkins, so no static ports.
-version: '3'
+version: '3.3'
 
 services:
   # We need a postgress server for VIP to initialize the database on.
@@ -19,13 +19,9 @@ services:
     image: openagency-php-local/openagency-php${DOCKER_IMAGE_TAG}
     environment:
       - VIP_CREDENTIALS=psql://vip:vippass@vip-postgres:5432/vip_db
-      # This is maintained if we need testing of the postgresql parsing thing.
-      # - VIP_CREDENTIALS=host=vip-postgres port=5432 dbname=vip_db user=vip password=vippass connect_timeout=1
-      - URL_PATH=staging_2.34
+      - URL_PATH=test_oa
       - FORS_RIGHTS=https://forsrights.addi.dk/1.2/?action=forsRights&outputType=php&userIdAut=%s&groupIdAut=%s&passwordAut=%s&ipAddress=%s
       - APACHE_SERVER_NAME=localhost
-      #- HTTP_PROXY=http://borchk-hoverfly:8500
-      #- HTTP_PROXY_INSECURE_MODE_FOR_TEST_ONLY=1
       - COPA_RS_URL=https://iso18626.addi.dk/copa-rs/app/iso18626/
       - COPA_RS_PASSWD=xxxxxxxxxxxx
     depends_on:
@@ -35,16 +31,21 @@ services:
     ports:
       - 80
 
-  # Debug container - will open for ports internally, on fixed ports
-  debug:
-    image: docker-i.dbc.dk/debug-container
-    ports:
-      - "5432:5432"
-      - "8080:8080"
-      # - "8081:8081"
+
+  openagency-gold:
+    image: docker-i.dbc.dk/openagency-php:133
     environment:
-      FORWARD_VIP_DB: 'localhost:5432 to vip-postgres:5432 as Access to VIP test DB'
-      FORWARD_OPENAGENCY: 'localhost:8080 to openagency-php:80 as Access to openagency-php http'
-      # FORWARD_VIP: 'localhost:8081 to vip-core:8080 as Access to VIP http'
+    - VIP_CREDENTIALS=psql://vip:vippass@vip-postgres:5432/vip_db
+    - URL_PATH=gold_oa
+    - FORS_RIGHTS=https://forsrights.addi.dk/1.2/?action=forsRights&outputType=php&userIdAut=%s&groupIdAut=%s&passwordAut=%s&ipAddress=%s
+    - APACHE_SERVER_NAME=localhost
+    - COPA_RS_URL=https://iso18626.addi.dk/copa-rs/app/iso18626/
+    - COPA_RS_PASSWD=xxxxxxxxxxxx
+    depends_on:
+    - "vip-postgres"
+    expose:
+    - 80
+    ports:
+    - 80
 
 

--- a/docker/compose/systemtest/docker-compose.yml
+++ b/docker/compose/systemtest/docker-compose.yml
@@ -4,13 +4,7 @@ version: '3'
 services:
   # We need a postgress server for VIP to initialize the database on.
   vip-postgres:
-    image: docker.dbc.dk/dbc-postgres:10
-    environment:
-      # Note, if you change the databasename, you must update the run-system-test script, that loads some data
-      # into the database. This could probably be avoided by using this image smarter.
-      - POSTGRES_DB=vip_db
-      - POSTGRES_USER=vip_user
-      - POSTGRES_PASSWORD=vip_password
+    image: docker-i.dbc.dk/vip-dit-test-data
     expose:
       - 5432
     ports:

--- a/run-system-test.sh
+++ b/run-system-test.sh
@@ -26,10 +26,14 @@ function setSysVars() {
 TESTRUN_PASSED=1
 function runTest() {
   info "Starting test"
-#  ${DOCKER_COMPOSE} up --force-recreate ${SOAPUI_SERVICE} || die "SOAPUI service start failed"
-#  RESULT=$(docker-compose ps -q ${SOAPUI_SERVICE} | xargs docker inspect -f '{{.State.ExitCode}}')
-  info "Test not yet implemented"
-  RESULT=0
+  JUNIT_RESULT_DIR=${BASE_DIR}/junit_results
+  [ -d "$JUNIT_RESULT_DIR" ] || mkdir "$JUNIT_RESULT_DIR"
+  JUNIT_RESULT_DIR=$(realpath "$JUNIT_RESULT_DIR")
+  info "Starting oa brute force tester"
+  TEST_IP=$(getIPofContainer "$WS_SERVICE")
+  GOLD_IP=$(getIPofContainer "$WS_SERVICE_GOLD")
+  docker run --rm -e BUILD_NUMBER --network=openagency-phpsystemtest_default -ti -v "$JUNIT_RESULT_DIR:/output" docker-i.dbc.dk/oa-tester "http://$GOLD_IP:80/gold_oa/" "http://$TEST_IP:80/test_oa/"
+  RESULT=$?
   info "Result of test is : " ${RESULT}
   TESTRUN_PASSED=${RESULT}
 }

--- a/shared_test.sh
+++ b/shared_test.sh
@@ -15,11 +15,11 @@
 # VIP_POSTGRES  : Test / fake database
 # VIP_CORE      : Only used to initialise the database in the test image.
 # WS            : The actual service under test (production image)
-# SOAPUI        : The service used to run soapui, for testing the WS service (test image)
 
 
 # Names of the docker compose services. These should match the ones in the systemtest/docker-compose.yml file
 WS_SERVICE="openagency-php"
+WS_SERVICE_GOLD="openagency-gold"
 VIP_POSTGRES_SERVICE="vip-postgres"
 
 # Names of the actual docker images. These should match the ones in the systemtest/docker-compose.yml file
@@ -66,23 +66,16 @@ function check_on_path() {
 # Pulling is not performed, if we are running locally.
 function pullImages() {
   info "Updating non project images to newest from docker-i.dbc.dk. Errors are ignored."
-  # docker pull ${SOAPUI_IMAGE}
   docker pull ${VIP_POSTGRES_IMAGE}
   docker pull ${VIP_CORE_IMAGE}
+  docker pull ${VIP_CORE_IMAGE_GOLD}
 }
 
 # Start the basecontainers. These are the containers that are used in both tests.
 function startBaseContainers() {
   info "Starting base containers"
-  # Note, the postgress image needs to be up and running, before the vip image, which is why we start it first
-  # We could wait on it, but the vip core service is something like 15 seconds in starting up, so the
-  # db container is in practice ready a long time before that.
-  # TODO: I can see that APO has removed the force-recreate from a similar file. Perhaps they are not useful?
-  ${DOCKER_COMPOSE} up --force-recreate -d ${VIP_POSTGRES_SERVICE} || die "docker-compose up -d ${VIP_POSTGRES_SERVICE}"
-  ${DOCKER_COMPOSE} up --force-recreate -d ${WS_SERVICE}           || die "docker-compose up -d ${WS_SERVICE}"
-  }
-
-
+  ${DOCKER_COMPOSE} up --force-recreate -d  || die "docker-compose up -d "
+}
 
 # Arguments:
 # 1: URL
@@ -149,6 +142,10 @@ function checkServiceMatch() {
     return 1
 }
 
+# get the ip of the named container
+function getIPofContainer( ) {
+  ${DOCKER_COMPOSE} exec $1 hostname -i | tr -d '\r'
+}
 
 # Wait for OK from the WS service.
 function waitForOk() {
@@ -156,41 +153,39 @@ function waitForOk() {
   # It is assumed that the proxy container is up very quickly, and that the vip db container is up quicker than the vip container.
 
   # Wait for the service/gui under test to be ready
-  WS_SERVICE_CONTAINERID=$(docker-compose ps -q ${WS_SERVICE}) || die "Unable to obtain container id for compose service ${WS_SERVICE}"
-  WS_SERVICE_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' ${WS_SERVICE_CONTAINERID}) \
-    || die "Unable to get ws service port mapping for container ${WS_SERVICE_CONTAINERID} for compose service ${WS_SERVICE}"
-  info "WS_SERVICE_PORT=${WS_SERVICE_PORT}"
+  WS_SERVICE_IP=$(getIPofContainer ${WS_SERVICE})
+
+  info "WS_SERVICE_IP=${WS_SERVICE_IP}"
   info "Waiting for ws container to be ready"
   # The normal HowRU requires a bunch of data in the database and returns 503, when not ready.
   # We just want - at this point - to make sure we are talking to the database
   # and that the datamodel is sort of OK
   # Abuse this to check that the service is running.
-  # waitFor200 "http://${HOST_IP}:${WS_SERVICE_PORT}/server.php?HowRU" 300 openagency-php || die "openagency-php service not ready in 300 seconds"
-  waitFor200 "http://${HOST_IP}:${WS_SERVICE_PORT}/staging_2.34/server.php?action=service&agencyId=710100&service=orsItemRequest" 300 openagency-php || die "openagency-php service not ready in 300 seconds"
-
-  # If we are connected to the database, it would appear we get a 200 with
-  # <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:oa="http://oss.dbc.dk/ns/openagency">
-  # <SOAP-ENV:Body><oa:serviceResponse><oa:error>agency_not_found</oa:error></oa:serviceResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
-
-  # If we are NOT connected to the database, we get
-  # <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:oa="http://oss.dbc.dk/ns/openagency">
-  # <SOAP-ENV:Body><oa:serviceResponse><oa:error>service_unavailable</oa:error></oa:serviceResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
-
-  # Make sure we are connnected to something.
-
-  # You can use these two lines to force connect errors in the database log, during development
-  # VIP_POSTGRES_CONTAINERID=$(docker-compose ps -q ${VIP_POSTGRES_SERVICE}) || die "Unable to obtain container id for compose service ${VIP_POSTGRES_SERVICE}"
-  # docker kill ${VIP_POSTGRES_CONTAINERID} || die "Unable to kill postgres container"
+  waitFor200 "http://${WS_SERVICE_IP}:80/test_oa/server.php?HowRU" 300 openagency-php || die "openagency-php service not ready in 300 seconds"
 
   # This uses "service"
   info "Checking openagency.service call"
-  checkServiceMatch "http://${HOST_IP}:${WS_SERVICE_PORT}/staging_2.34/server.php?action=service&agencyId=710100&service=orsItemRequest" openagency-php "<oa:responder>710100</oa:responder>"
+  checkServiceMatch "http://${WS_SERVICE_IP}:80/test_oa/server.php?action=service&agencyId=710100&service=orsItemRequest" openagency-php "<oa:responder>710100</oa:responder>"
   # But, we also want this, to check the log when debugging.
   info "Checking openagency.service call basic"
-  checkServiceMatch "http://${HOST_IP}:${WS_SERVICE_PORT}/staging_2.34/server.php?action=openSearchProfile&agencyId=710100&profileName=foobar&profileVersion=3" openagency-php openSearchProfileResponse
+  checkServiceMatch "http://${WS_SERVICE_IP}:80/test_oa/server.php?action=openSearchProfile&agencyId=710100&profileName=foobar&profileVersion=3" openagency-php openSearchProfileResponse
   # This is related to VP-262
   info "Checking openagency.openSearchProfile call with missing agencyId"
-  checkServiceMatch "http://${HOST_IP}:${WS_SERVICE_PORT}/staging_2.34/server.php?action=openSearchProfile&agencyId=&profileVersion=3&trackingId=2019-10-02T14:40:09:509991:3648" openagency-php agency_not_found
+  checkServiceMatch "http://${WS_SERVICE_IP}:80/test_oa/server.php?action=openSearchProfile&agencyId=&profileVersion=3&trackingId=2019-10-02T14:40:09:509991:3648" openagency-php agency_not_found
+
+
+  info "Wait for gold service to start"
+  WS_SERVICE_GOLD_IP=$(getIPofContainer ${WS_SERVICE_GOLD})
+
+  info "WS_SERVICE_GOLD_IP=${WS_SERVICE_GOLD_IP}"
+  info "Waiting for ws container to be ready"
+  # The normal HowRU requires a bunch of data in the database and returns 503, when not ready.
+  # We just want - at this point - to make sure we are talking to the database
+  # and that the datamodel is sort of OK
+  # Abuse this to check that the service is running.
+  waitFor200 "http://${WS_SERVICE_GOLD_IP}:80/gold_oa/server.php?HowRU" 300 openagency-php || die "openagency-php service not ready in 300 seconds"
+
+
 }
 
 # Print info about how to stop containers.


### PR DESCRIPTION
using prepopulated database brings time for ./scripts/test from 45 seconds to blow 10 seconds